### PR TITLE
Support parent request

### DIFF
--- a/pkg/checkpoint/models/algorithm_request.go
+++ b/pkg/checkpoint/models/algorithm_request.go
@@ -9,6 +9,13 @@ type AlgorithmRequestRef struct {
 	AlgorithmName string `json:"algorithmName" binding:"required"`
 }
 
+func (r *AlgorithmRequestRef) DeepCopy() *AlgorithmRequestRef {
+	return &AlgorithmRequestRef{
+		RequestId:     r.RequestId,
+		AlgorithmName: r.AlgorithmName,
+	}
+}
+
 type AlgorithmRequest struct {
 	AlgorithmParameters map[string]interface{} `json:"algorithmParameters" binding:"required"`
 	CustomConfiguration *v1.NexusAlgorithmSpec `json:"customConfiguration,omitempty"`

--- a/pkg/checkpoint/models/checkpointed_request_test.go
+++ b/pkg/checkpoint/models/checkpointed_request_test.go
@@ -60,7 +60,7 @@ func getFakeRequest() *CheckpointedRequest {
 		Tag:                    "abc",
 		ApiVersion:             "1.2",
 		JobUid:                 "1231",
-		ParentJob:              nil,
+		Parent:                 nil,
 		PayloadValidFor:        "86400s",
 	}
 }
@@ -99,7 +99,7 @@ func TestCheckpointedRequest_ToCqlModel(t *testing.T) {
 		Tag:                     fakeRequest.Tag,
 		ApiVersion:              fakeRequest.ApiVersion,
 		JobUid:                  fakeRequest.JobUid,
-		ParentJob:               "",
+		Parent:                  "{}",
 		PayloadValidFor:         "86400s",
 	}
 
@@ -135,6 +135,11 @@ func TestCheckpointedRequest_ToV1Job(t *testing.T) {
 		Cluster:      "shard-0",
 		Tolerations:  nil,
 		Affinity:     nil,
+	}, &metav1.OwnerReference{
+		APIVersion: v1.SchemeGroupVersion.String(),
+		Kind:       "NexusAlgorithmTemplate",
+		Name:       "test-parent",
+		UID:        "test-uid",
 	})
 
 	expectedJob := &batchv1.Job{
@@ -148,6 +153,14 @@ func TestCheckpointedRequest_ToV1Job(t *testing.T) {
 				JobTemplateNameKey:          fakeRequest.Algorithm,
 				JobLabelFrameworkVersionKey: "v0.0.0",
 				NexusComponentLabel:         JobLabelAlgorithmRun,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: v1.SchemeGroupVersion.String(),
+					Kind:       "NexusAlgorithmTemplate",
+					Name:       "test-parent",
+					UID:        "test-uid",
+				},
 			},
 		},
 		Spec: batchv1.JobSpec{

--- a/pkg/checkpoint/models/parent_job.go
+++ b/pkg/checkpoint/models/parent_job.go
@@ -1,3 +1,0 @@
-package models
-
-type ParentJobReference struct{}

--- a/pkg/checkpoint/models/submission_buffer_entry.go
+++ b/pkg/checkpoint/models/submission_buffer_entry.go
@@ -7,6 +7,7 @@ import (
 	"github.com/SneaksAndData/nexus-core/pkg/buildmeta"
 	"github.com/scylladb/gocqlx/v3/table"
 	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var SubmissionBufferTable = table.New(table.Metadata{
@@ -41,8 +42,8 @@ func (sbe *SubmissionBufferEntry) SubmissionTemplate() (*batchv1.Job, error) {
 	return result, nil
 }
 
-func FromCheckpoint(checkpoint *CheckpointedRequest, resolvedWorkgroup *v1.NexusAlgorithmWorkgroupSpec) *SubmissionBufferEntry {
-	jobTemplate, _ := json.Marshal(checkpoint.ToV1Job(fmt.Sprintf("%s-%s", buildmeta.AppVersion, buildmeta.BuildNumber), resolvedWorkgroup))
+func FromCheckpoint(checkpoint *CheckpointedRequest, resolvedWorkgroup *v1.NexusAlgorithmWorkgroupSpec, resolvedParent *metav1.OwnerReference) *SubmissionBufferEntry {
+	jobTemplate, _ := json.Marshal(checkpoint.ToV1Job(fmt.Sprintf("%s-%s", buildmeta.AppVersion, buildmeta.BuildNumber), resolvedWorkgroup, resolvedParent))
 
 	return &SubmissionBufferEntry{
 		Algorithm: checkpoint.Algorithm,

--- a/pkg/checkpoint/request/buffer.go
+++ b/pkg/checkpoint/request/buffer.go
@@ -5,6 +5,7 @@ import (
 	"github.com/SneaksAndData/nexus-core/pkg/checkpoint/models"
 	"github.com/SneaksAndData/nexus-core/pkg/pipeline"
 	"iter"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"time"
 )
@@ -32,6 +33,7 @@ type BufferConfig struct {
 type BufferInput struct {
 	Checkpoint        *models.CheckpointedRequest
 	ResolvedWorkgroup *v1.NexusAlgorithmWorkgroupSpec
+	ResolvedParent    *metav1.OwnerReference
 	SerializedPayload *[]byte
 	Config            *v1.NexusAlgorithmSpec
 }
@@ -48,7 +50,7 @@ func (input *BufferInput) Tags() map[string]string {
 	}
 }
 
-func NewBufferInput(requestId string, algorithmName string, request *models.AlgorithmRequest, config *v1.NexusAlgorithmSpec, workgroup *v1.NexusAlgorithmWorkgroupSpec) (*BufferInput, error) {
+func NewBufferInput(requestId string, algorithmName string, request *models.AlgorithmRequest, config *v1.NexusAlgorithmSpec, workgroup *v1.NexusAlgorithmWorkgroupSpec, parent *metav1.OwnerReference) (*BufferInput, error) {
 	checkpoint, serializedPayload, err := models.FromAlgorithmRequest(requestId, algorithmName, request, config)
 
 	if err != nil {
@@ -58,6 +60,7 @@ func NewBufferInput(requestId string, algorithmName string, request *models.Algo
 	return &BufferInput{
 		Checkpoint:        checkpoint,
 		ResolvedWorkgroup: workgroup,
+		ResolvedParent:    parent,
 		SerializedPayload: &serializedPayload,
 		Config:            config,
 	}, nil

--- a/pkg/checkpoint/request/memory_passthrough_buffer.go
+++ b/pkg/checkpoint/request/memory_passthrough_buffer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/SneaksAndData/nexus-core/pkg/pipeline"
 	"github.com/SneaksAndData/nexus-core/pkg/telemetry"
 	"iter"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"time"
@@ -93,8 +94,8 @@ func (buffer *MemoryPassthroughBuffer) GetBufferedEntry(checkpoint *models.Check
 	return nil, nil
 }
 
-func (buffer *MemoryPassthroughBuffer) Add(requestId string, algorithmName string, request *models.AlgorithmRequest, config *v1.NexusAlgorithmSpec, workgroup *v1.NexusAlgorithmWorkgroupSpec) error {
-	input, err := NewBufferInput(requestId, algorithmName, request, config, workgroup)
+func (buffer *MemoryPassthroughBuffer) Add(requestId string, algorithmName string, request *models.AlgorithmRequest, config *v1.NexusAlgorithmSpec, workgroup *v1.NexusAlgorithmWorkgroupSpec, parent *metav1.OwnerReference) error {
+	input, err := NewBufferInput(requestId, algorithmName, request, config, workgroup, parent)
 	if err != nil {
 		return err
 	}
@@ -108,7 +109,7 @@ func (buffer *MemoryPassthroughBuffer) bufferRequest(input *BufferInput) (*Buffe
 	bufferedCheckpoint.LifecycleStage = models.LifecycleStageBuffered
 	bufferedCheckpoint.PayloadUri = "memory"
 	bufferedCheckpoint.PayloadValidFor = "24h"
-	entry := models.FromCheckpoint(bufferedCheckpoint, input.ResolvedWorkgroup)
+	entry := models.FromCheckpoint(bufferedCheckpoint, input.ResolvedWorkgroup, input.ResolvedParent)
 
 	buffer.Checkpoints = append(buffer.Checkpoints, input.Checkpoint)
 	buffer.BufferedEntries = append(buffer.BufferedEntries, entry)

--- a/test-resources/storage/checkpoints.cql
+++ b/test-resources/storage/checkpoints.cql
@@ -17,7 +17,7 @@ create table nexus.checkpoints
     tag                       text,
     api_version               text,
     job_uid                   text,
-    parent_job                text,
+    parent                    text,
     payload_valid_for         text,
     PRIMARY KEY ((algorithm, id))
 );
@@ -31,7 +31,7 @@ create index lifecycle_stage ON nexus.checkpoints (lifecycle_stage);
 INSERT INTO nexus.checkpoints (algorithm, id, lifecycle_stage, payload_uri, result_uri, algorithm_failure_cause,
                                algorithm_failure_details, received_by_host, received_at, sent_at, applied_configuration,
                                configuration_overrides, content_hash, last_modified, tag, api_version,
-                               job_uid, parent_job, payload_valid_for)
+                               job_uid, parent, payload_valid_for)
 VALUES ('test-algorithm', 'f47ac10b-58cc-4372-a567-0e02b2c3d479', 'NEW', 'http://localhost/payload',
         'http://localhost/result', NULL, NULL, 'host123', '2023-10-01T12:00:00.000Z',
         '2023-10-01T12:30:00.000Z', '{}', '{}', 'new_hash', '2023-10-01T12:45:00.000Z',
@@ -40,7 +40,7 @@ VALUES ('test-algorithm', 'f47ac10b-58cc-4372-a567-0e02b2c3d479', 'NEW', 'http:/
 INSERT INTO nexus.checkpoints (algorithm, id, lifecycle_stage, payload_uri, result_uri, algorithm_failure_cause,
                                algorithm_failure_details, received_by_host, received_at, sent_at, applied_configuration,
                                configuration_overrides, content_hash, last_modified, tag, api_version,
-                               job_uid, parent_job, payload_valid_for)
+                               job_uid, parent, payload_valid_for)
 VALUES ('test-algorithm', '2c7b6e8d-cc3c-4b5b-a3f6-5d7b9e2c7f2a', 'BUFFERED', 'http://localhost/payload',
         'http://localhost/result', NULL, NULL, 'host123', '2023-10-02T10:00:00.000Z',
         '2023-10-02T10:30:00.000Z', '{}', '{}', 'buffered_hash', '2023-10-02T10:45:00.000Z',
@@ -49,7 +49,7 @@ VALUES ('test-algorithm', '2c7b6e8d-cc3c-4b5b-a3f6-5d7b9e2c7f2a', 'BUFFERED', 'h
 INSERT INTO nexus.checkpoints (algorithm, id, lifecycle_stage, payload_uri, result_uri, algorithm_failure_cause,
                                algorithm_failure_details, received_by_host, received_at, sent_at, applied_configuration,
                                configuration_overrides, content_hash, last_modified, tag, api_version,
-                               job_uid, parent_job, payload_valid_for)
+                               job_uid, parent, payload_valid_for)
 VALUES ('test-algorithm', '8a0c8aa9-fc9d-4b2e-9c5c-2c8d7f1e7a3f', 'RUNNING', 'http://localhost/payload',
         'http://localhost/result', NULL, NULL, 'host789', '2023-10-03T08:00:00.000Z',
         '2023-10-03T08:15:00.000Z', '{}', '{}', 'running_hash', '2023-10-03T08:30:00.000Z',
@@ -58,7 +58,7 @@ VALUES ('test-algorithm', '8a0c8aa9-fc9d-4b2e-9c5c-2c8d7f1e7a3f', 'RUNNING', 'ht
 INSERT INTO nexus.checkpoints (algorithm, id, lifecycle_stage, payload_uri, result_uri, algorithm_failure_cause,
                                algorithm_failure_details, received_by_host, received_at, sent_at, applied_configuration,
                                configuration_overrides, content_hash, last_modified, tag, api_version,
-                               job_uid, parent_job, payload_valid_for)
+                               job_uid, parent, payload_valid_for)
 VALUES ('test-algorithm', '550e8400-e29b-41d4-a716-446655440000', 'COMPLETED', 'http://localhost/payload',
         'http://localhost/result', NULL, NULL, 'host999', '2023-10-04T09:00:00.000Z',
         '2023-10-04T09:30:00.000Z', '{}', '{}', 'completed_hash', '2023-10-04T09:45:00.000Z',
@@ -67,7 +67,7 @@ VALUES ('test-algorithm', '550e8400-e29b-41d4-a716-446655440000', 'COMPLETED', '
 INSERT INTO nexus.checkpoints (algorithm, id, lifecycle_stage, payload_uri, result_uri, algorithm_failure_cause,
                                algorithm_failure_details, received_by_host, received_at, sent_at, applied_configuration,
                                configuration_overrides, content_hash, last_modified, tag, api_version,
-                               job_uid, parent_job, payload_valid_for)
+                               job_uid, parent, payload_valid_for)
 VALUES ('test-algorithm', 'c3b7f1e7-9c5c-4b2e-8a0c-8aa9fc9d7f1e', 'FAILED', 'http://localhost/payload',
         'http://localhost/result', 'error', 'Unhandled exception occurred.', 'host321',
         '2023-10-05T10:00:00.000Z', '2023-10-05T10:30:00.000Z', '{}', '{}', 'failed_hash',
@@ -76,7 +76,7 @@ VALUES ('test-algorithm', 'c3b7f1e7-9c5c-4b2e-8a0c-8aa9fc9d7f1e', 'FAILED', 'htt
 INSERT INTO nexus.checkpoints (algorithm, id, lifecycle_stage, payload_uri, result_uri, algorithm_failure_cause,
                                algorithm_failure_details, received_by_host, received_at, sent_at, applied_configuration,
                                configuration_overrides, content_hash, last_modified, tag, api_version,
-                               job_uid, parent_job, payload_valid_for)
+                               job_uid, parent, payload_valid_for)
 VALUES ('test-algorithm', '7f1e8a9c-4d1c-4f5b-a3f7-9c5b1e7b3c8d', 'SCHEDULING_FAILED', 'http://localhost/payload',
         'http://localhost/result', 'scheduling_error', 'Could not schedule the job.', 'host654',
         '2023-10-06T11:00:00.000Z', '2023-10-06T11:30:00.000Z', '{}', '{}', 'scheduling_failed_hash',
@@ -86,7 +86,7 @@ VALUES ('test-algorithm', '7f1e8a9c-4d1c-4f5b-a3f7-9c5b1e7b3c8d', 'SCHEDULING_FA
 INSERT INTO nexus.checkpoints (algorithm, id, lifecycle_stage, payload_uri, result_uri, algorithm_failure_cause,
                                algorithm_failure_details, received_by_host, received_at, sent_at, applied_configuration,
                                configuration_overrides, content_hash, last_modified, tag, api_version,
-                               job_uid, parent_job, payload_valid_for)
+                               job_uid, parent, payload_valid_for)
 VALUES ('test-algorithm', '9c5b1e7b-4d1c-4f5b-a3f7-1e7b3c8d8a9f', 'DEADLINE_EXCEEDED', 'http://localhost/payload',
         'http://localhost/result', 'deadline_exceeded', 'The job ran out of time.', 'host987',
         '2023-10-07T12:00:00.000Z', '2023-10-07T12:30:00.000Z', '{}', '{}', 'deadline_exceeded_hash',
@@ -95,7 +95,7 @@ VALUES ('test-algorithm', '9c5b1e7b-4d1c-4f5b-a3f7-1e7b3c8d8a9f', 'DEADLINE_EXCE
 INSERT INTO nexus.checkpoints (algorithm, id, lifecycle_stage, payload_uri, result_uri, algorithm_failure_cause,
                                algorithm_failure_details, received_by_host, received_at, sent_at, applied_configuration,
                                configuration_overrides, content_hash, last_modified, tag, api_version,
-                               job_uid, parent_job, payload_valid_for)
+                               job_uid, parent, payload_valid_for)
 VALUES ('test-algorithm', '4d5b9f2c-1e7b-3c8d-8a9f-4a0c8b1e7b3f', 'CANCELLED', 'http://localhost/payload',
         'http://localhost/result', 'cancelled_by_user', 'The job was cancelled by the user.', 'host111',
         '2023-10-08T13:00:00.000Z', '2023-10-08T13:30:00.000Z', '{}', '{}', 'cancelled_hash',


### PR DESCRIPTION
One of the last remaining features from https://github.com/SneaksAndData/nexus/issues/5

Implementation assumes that job reference is created externally and passed to the buffer. All calls to Cassandra that were done in the private version are not needed here, since we'll simply extract parent info from informer cache.