### PR TITLE
[Checkpoint Store] Serialize JSON fields as base64 strings instead of plain text

### DIFF
--- a/pkg/checkpoint/models/checkpointed_request.go
+++ b/pkg/checkpoint/models/checkpointed_request.go
@@ -248,7 +248,7 @@ func (c *CheckpointedRequestCqlModel) getParent() (*AlgorithmRequestRef, error) 
 }
 
 func (c *CheckpointedRequestCqlModel) FromCqlModel() (*CheckpointedRequest, error) {
-	appliedConfig := &v1.NexusAlgorithmSpec{}
+	var appliedConfig *v1.NexusAlgorithmSpec
 	var overrides *v1.NexusAlgorithmSpec
 	var parent *AlgorithmRequestRef
 

--- a/pkg/checkpoint/models/checkpointed_request.go
+++ b/pkg/checkpoint/models/checkpointed_request.go
@@ -1,8 +1,8 @@
 package models
 
 import (
+	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	v1 "github.com/SneaksAndData/nexus-core/pkg/apis/science/v1"
 	"github.com/aws/smithy-go/ptr"
@@ -32,6 +32,7 @@ const (
 	JobLabelFrameworkVersionKey = "science.sneaksanddata.com/nexus-version"
 	NexusComponentLabel         = "science.sneaksanddata.com/nexus-component"
 	JobLabelAlgorithmRun        = "algorithm-run"
+	EncodePrefix                = "b64__"
 )
 
 type CheckpointedRequest struct {
@@ -162,14 +163,14 @@ func (c *CheckpointedRequest) ToCqlModel() (*CheckpointedRequestCqlModel, error)
 		ReceivedByHost:          c.ReceivedByHost,
 		ReceivedAt:              c.ReceivedAt,
 		SentAt:                  c.SentAt,
-		AppliedConfiguration:    string(serializedConfig),
-		ConfigurationOverrides:  string(serializedOverrides),
+		AppliedConfiguration:    fmt.Sprintf("%s%s", EncodePrefix, base64.StdEncoding.EncodeToString(serializedConfig)),
+		ConfigurationOverrides:  fmt.Sprintf("%s%s", EncodePrefix, base64.StdEncoding.EncodeToString(serializedOverrides)),
 		ContentHash:             c.ContentHash,
 		LastModified:            c.LastModified,
 		Tag:                     c.Tag,
 		ApiVersion:              c.ApiVersion,
 		JobUid:                  c.JobUid,
-		Parent:                  string(parent),
+		Parent:                  fmt.Sprintf("%s%s", EncodePrefix, base64.StdEncoding.EncodeToString(parent)),
 		PayloadValidFor:         c.PayloadValidFor,
 	}, nil
 }
@@ -183,6 +184,69 @@ func (c *CheckpointedRequest) PayloadValidityPeriod() *time.Duration {
 	return &result
 }
 
+func (c *CheckpointedRequestCqlModel) readSerializedSpec(serializedSpec string) (*v1.NexusAlgorithmSpec, error) {
+	spec := &v1.NexusAlgorithmSpec{}
+	var serializedValue []byte
+	var err error
+
+	if serializedSpec == "{}" || serializedSpec == "" {
+		return nil, nil
+	}
+
+	// backwards-compatible code: only use b64 decode if it was used to write the value
+	if strings.HasPrefix(serializedSpec, EncodePrefix) {
+		serializedValue, err = base64.StdEncoding.DecodeString(strings.TrimPrefix(serializedSpec, EncodePrefix))
+		if err != nil {
+			return nil, err
+		}
+
+		if string(serializedValue) == "{}" || string(serializedValue) == "" {
+			return nil, nil
+		}
+	} else {
+		serializedValue = []byte(serializedSpec)
+	}
+
+	err = json.Unmarshal(serializedValue, spec)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return spec, nil
+}
+
+func (c *CheckpointedRequestCqlModel) getParent() (*AlgorithmRequestRef, error) {
+	parent := &AlgorithmRequestRef{}
+	var serializedValue []byte
+	var err error
+
+	if c.Parent == "" || c.Parent == "{}" {
+		return nil, nil
+	}
+
+	// backwards-compatible code: only use b64 decode if it was used to write the value
+	if strings.HasPrefix(c.Parent, EncodePrefix) {
+		serializedValue, err = base64.StdEncoding.DecodeString(strings.TrimPrefix(c.Parent, EncodePrefix))
+		if err != nil {
+			return nil, err
+		}
+
+		if string(serializedValue) == "{}" || string(serializedValue) == "" {
+			return nil, nil
+		}
+	} else {
+		serializedValue = []byte(c.Parent)
+	}
+	err = json.Unmarshal(serializedValue, parent)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return parent, nil
+}
+
 func (c *CheckpointedRequestCqlModel) FromCqlModel() (*CheckpointedRequest, error) {
 	appliedConfig := &v1.NexusAlgorithmSpec{}
 	var overrides *v1.NexusAlgorithmSpec
@@ -191,17 +255,19 @@ func (c *CheckpointedRequestCqlModel) FromCqlModel() (*CheckpointedRequest, erro
 	var unmarshalErr error
 
 	// ignore override unmarshal if set to empty object
-	if c.ConfigurationOverrides == "{}" || c.ConfigurationOverrides == "" {
-		unmarshalErr = json.Unmarshal([]byte(c.AppliedConfiguration), appliedConfig)
-	} else { // coverage-ignore
-		overrides = &v1.NexusAlgorithmSpec{}
-		unmarshalErr = errors.Join(json.Unmarshal([]byte(c.AppliedConfiguration), appliedConfig), json.Unmarshal([]byte(c.ConfigurationOverrides), overrides))
+	overrides, unmarshalErr = c.readSerializedSpec(c.ConfigurationOverrides)
+
+	if unmarshalErr != nil {
+		return nil, unmarshalErr
 	}
 
-	if c.Parent != "" && c.Parent != "{}" {
-		parent = &AlgorithmRequestRef{}
-		unmarshalErr = errors.Join(unmarshalErr, json.Unmarshal([]byte(c.Parent), parent))
+	appliedConfig, unmarshalErr = c.readSerializedSpec(c.AppliedConfiguration)
+
+	if unmarshalErr != nil {
+		return nil, unmarshalErr
 	}
+
+	parent, unmarshalErr = c.getParent()
 
 	if unmarshalErr != nil {
 		return nil, unmarshalErr

--- a/pkg/checkpoint/models/checkpointed_request_test.go
+++ b/pkg/checkpoint/models/checkpointed_request_test.go
@@ -98,14 +98,14 @@ func TestCheckpointedRequest_ToCqlModel(t *testing.T) {
 		ReceivedByHost:          fakeRequest.ReceivedByHost,
 		ReceivedAt:              fakeRequest.ReceivedAt,
 		SentAt:                  fakeRequest.SentAt,
-		AppliedConfiguration:    "{\"container\":{\"image\":\"test.io\",\"registry\":\"algorithms/test\",\"versionTag\":\"v1.0.0\",\"serviceAccountName\":\"test-sa\"},\"computeResources\":{\"cpuLimit\":\"1000m\",\"memoryLimit\":\"2000Mi\"},\"workgroupRef\":{\"name\":\"test-workgroup\",\"group\":\"nexus-workgroup.io\",\"kind\":\"KarpenterWorkgroupV1\"},\"command\":\"python\",\"args\":[\"job.py\",\"--sas-uri=%s\",\"--request-id=%s\",\"--arg1=true\"],\"runtimeEnvironment\":{\"deadlineSeconds\":120,\"maximumRetries\":3},\"datadogIntegrationSettings\":{\"mountDatadogSocket\":true}}",
-		ConfigurationOverrides:  "{}",
+		AppliedConfiguration:    "b64__eyJjb250YWluZXIiOnsiaW1hZ2UiOiJ0ZXN0LmlvIiwicmVnaXN0cnkiOiJhbGdvcml0aG1zL3Rlc3QiLCJ2ZXJzaW9uVGFnIjoidjEuMC4wIiwic2VydmljZUFjY291bnROYW1lIjoidGVzdC1zYSJ9LCJjb21wdXRlUmVzb3VyY2VzIjp7ImNwdUxpbWl0IjoiMTAwMG0iLCJtZW1vcnlMaW1pdCI6IjIwMDBNaSJ9LCJ3b3JrZ3JvdXBSZWYiOnsibmFtZSI6InRlc3Qtd29ya2dyb3VwIiwiZ3JvdXAiOiJuZXh1cy13b3JrZ3JvdXAuaW8iLCJraW5kIjoiS2FycGVudGVyV29ya2dyb3VwVjEifSwiY29tbWFuZCI6InB5dGhvbiIsImFyZ3MiOlsiam9iLnB5IiwiLS1zYXMtdXJpPSVzIiwiLS1yZXF1ZXN0LWlkPSVzIiwiLS1hcmcxPXRydWUiXSwicnVudGltZUVudmlyb25tZW50Ijp7ImRlYWRsaW5lU2Vjb25kcyI6MTIwLCJtYXhpbXVtUmV0cmllcyI6M30sImRhdGFkb2dJbnRlZ3JhdGlvblNldHRpbmdzIjp7Im1vdW50RGF0YWRvZ1NvY2tldCI6dHJ1ZX19",
+		ConfigurationOverrides:  "b64__e30=",
 		ContentHash:             fakeRequest.ContentHash,
 		LastModified:            fakeRequest.LastModified,
 		Tag:                     fakeRequest.Tag,
 		ApiVersion:              fakeRequest.ApiVersion,
 		JobUid:                  fakeRequest.JobUid,
-		Parent:                  "{}",
+		Parent:                  "b64__e30=",
 		PayloadValidFor:         "86400s",
 	}
 
@@ -131,6 +131,42 @@ func TestCheckpointedRequest_FromCqlModel(t *testing.T) {
 		t.Errorf("Failed to deserialize a checkpoint from its cql model %s: values do not match", diff.ObjectGoPrintSideBySide(fakeRequest, fakeRequestFromModel))
 	}
 	t.Log("CheckpointedRequest.FromCqlModel() returns correct result")
+}
+
+func TestCheckpointedRequest_FromLegacyCqlModel(t *testing.T) {
+	expectedRequest := getFakeRequest(false)
+	legacyModel := &CheckpointedRequestCqlModel{
+		Algorithm:               expectedRequest.Algorithm,
+		Id:                      expectedRequest.Id,
+		LifecycleStage:          "RUNNING",
+		PayloadUri:              expectedRequest.PayloadUri,
+		ResultUri:               expectedRequest.ResultUri,
+		AlgorithmFailureCause:   expectedRequest.AlgorithmFailureCause,
+		AlgorithmFailureDetails: expectedRequest.AlgorithmFailureDetails,
+		ReceivedByHost:          expectedRequest.ReceivedByHost,
+		ReceivedAt:              expectedRequest.ReceivedAt,
+		SentAt:                  expectedRequest.SentAt,
+		AppliedConfiguration:    "{\"container\":{\"image\":\"test.io\",\"registry\":\"algorithms/test\",\"versionTag\":\"v1.0.0\",\"serviceAccountName\":\"test-sa\"},\"computeResources\":{\"cpuLimit\":\"1000m\",\"memoryLimit\":\"2000Mi\"},\"workgroupRef\":{\"name\":\"test-workgroup\",\"group\":\"nexus-workgroup.io\",\"kind\":\"KarpenterWorkgroupV1\"},\"command\":\"python\",\"args\":[\"job.py\",\"--sas-uri=%s\",\"--request-id=%s\",\"--arg1=true\"],\"runtimeEnvironment\":{\"deadlineSeconds\":120,\"maximumRetries\":3},\"datadogIntegrationSettings\":{\"mountDatadogSocket\":true}}",
+		ConfigurationOverrides:  "{}",
+		ContentHash:             expectedRequest.ContentHash,
+		LastModified:            expectedRequest.LastModified,
+		Tag:                     expectedRequest.Tag,
+		ApiVersion:              expectedRequest.ApiVersion,
+		JobUid:                  expectedRequest.JobUid,
+		Parent:                  "{}",
+		PayloadValidFor:         "86400s",
+	}
+
+	legacyRequest, err := legacyModel.FromCqlModel()
+
+	if err != nil {
+		t.Fatalf("Error when converting a legacy model back to a checkpoint: %s", err)
+	}
+
+	if !reflect.DeepEqual(legacyRequest, expectedRequest) {
+		t.Fatalf("Failed to convert request to a cql model %s: values do not match", diff.ObjectGoPrintSideBySide(legacyRequest, expectedRequest))
+	}
+	t.Log("CheckpointedRequest.ToCqlModel() returns correct result")
 }
 
 func TestCheckpointedRequest_ToV1Job(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/SneaksAndData/nexus-core/issues/58

Update the serialization and deserialization logic for the `CheckpointedRequest` model to use base64 encoding with a prefix for all fields that require JSON marshalling. This prevents the backend engine from stripping quotes from JSON values, making them unreadable.

**Serialization/Deserialization Improvements:**

* Updated the `ToCqlModel` method in `checkpointed_request.go` to base64-encode the `AppliedConfiguration`, `ConfigurationOverrides`, and `Parent` fields, and prefix them with `b64__` to indicate encoding.
* Added the constant `EncodePrefix` (`b64__`) to clearly mark encoded fields.
* Implemented helper methods (`readSerializedSpec` and `getParent`) in `CheckpointedRequestCqlModel` to decode fields, supporting both the new base64-prefixed format and the legacy plain JSON format for backwards compatibility.

**Testing Enhancements:**

* Updated existing tests to expect base64-encoded, prefixed strings for relevant fields.
* Added a new test, `TestCheckpointedRequest_FromLegacyCqlModel`, to ensure legacy (non-encoded) data is still correctly handled, verifying backwards compatibility.

**AI Summary - edited**