### PR TITLE
[URL Signing] Add utilities for secure url signing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/samber/slog-multi v1.4.0
 	github.com/scylladb/gocqlx/v3 v3.0.2
 	github.com/spf13/viper v1.20.1
+	golang.org/x/crypto v0.39.0
 	golang.org/x/time v0.12.0
 	k8s.io/api v0.33.2
 	k8s.io/apimachinery v0.33.2

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,8 @@ go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN8
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.39.0 h1:SHs+kF4LP+f+p14esP5jAoDpHU8Gu/v9lFRK6IT5imM=
+golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=

--- a/pkg/urlsign/signed_url.go
+++ b/pkg/urlsign/signed_url.go
@@ -40,7 +40,8 @@ func NewSignedFromSignature(unsigned url.URL, payload *signerPayload, sig []byte
 	sigBase64 := base64.RawURLEncoding.EncodeToString(sig)
 	urlQuery := unsigned.Query()
 	urlQuery.Add(SignatureQueryParamName, sigBase64)
-	urlQuery.Add(ExpiryQueryParamName, strconv.FormatInt(payload.expiry, 10))
+	urlQuery.Add(ValidFromQueryParamName, strconv.FormatInt(payload.validFrom, 10))
+	urlQuery.Add(ValidToQueryParamName, strconv.FormatInt(payload.validTo, 10))
 	urlQuery.Add(TenantQueryParamName, payload.tenantId)
 	urlQuery.Add(ChecksumQueryParamName, payload.checksum)
 

--- a/pkg/urlsign/signed_url.go
+++ b/pkg/urlsign/signed_url.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/url"
+	"strconv"
 )
 
 const (
@@ -35,10 +36,13 @@ func NewSignedFromUrl(signed url.URL) (*SignedUrl, error) {
 	}, nil
 }
 
-func NewSignedFromSignature(unsigned url.URL, sig []byte) (*SignedUrl, error) {
+func NewSignedFromSignature(unsigned url.URL, payload *signerPayload, sig []byte) (*SignedUrl, error) {
 	sigBase64 := base64.RawURLEncoding.EncodeToString(sig)
 	urlQuery := unsigned.Query()
 	urlQuery.Add(SignatureQueryParamName, sigBase64)
+	urlQuery.Add(ExpiryQueryParamName, strconv.FormatInt(payload.expiry, 10))
+	urlQuery.Add(TenantQueryParamName, payload.tenantId)
+	urlQuery.Add(ChecksumQueryParamName, payload.checksum)
 
 	unsigned.RawQuery = urlQuery.Encode()
 

--- a/pkg/urlsign/signed_url.go
+++ b/pkg/urlsign/signed_url.go
@@ -17,10 +17,10 @@ type SignedUrl struct {
 	Signature string
 }
 
-func NewSignedFromUrl(signed url.URL) (*SignedUrl, error) {
+func NewSignedFromUrl(signed url.URL) (*SignedUrl, error) { // coverage-ignore
 	parsed, err := signed.Parse(signed.String())
 
-	if err != nil {
+	if err != nil { // coverage-ignore
 		return nil, err
 	}
 

--- a/pkg/urlsign/signed_url.go
+++ b/pkg/urlsign/signed_url.go
@@ -1,0 +1,49 @@
+package urlsign
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/url"
+)
+
+const (
+	SignatureQueryParamName = "sig"
+)
+
+// SignedUrl hold a url and a its signature in a separate field
+type SignedUrl struct {
+	Url       *url.URL
+	Signature string
+}
+
+func NewSignedFromUrl(signed url.URL) (*SignedUrl, error) {
+	parsed, err := signed.Parse(signed.String())
+
+	if err != nil {
+		return nil, err
+	}
+
+	signature := parsed.Query().Get(SignatureQueryParamName)
+
+	if signature == "" {
+		return nil, fmt.Errorf("cannot create a signed url reference for url %s - no `%s` parameter found", SignatureQueryParamName, signed.String())
+	}
+
+	return &SignedUrl{
+		Url:       parsed,
+		Signature: signature,
+	}, nil
+}
+
+func NewSignedFromSignature(unsigned url.URL, sig []byte) (*SignedUrl, error) {
+	sigBase64 := base64.RawURLEncoding.EncodeToString(sig)
+	urlQuery := unsigned.Query()
+	urlQuery.Add(SignatureQueryParamName, sigBase64)
+
+	unsigned.RawQuery = urlQuery.Encode()
+
+	return &SignedUrl{
+		Url:       &unsigned,
+		Signature: sigBase64,
+	}, nil
+}

--- a/pkg/urlsign/signer_api.go
+++ b/pkg/urlsign/signer_api.go
@@ -1,0 +1,67 @@
+package urlsign
+
+import (
+	"crypto/subtle"
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"time"
+
+	"golang.org/x/crypto/blake2b"
+)
+
+// Sign uses a provided secret to generate a cryptographic signature for the provided unsigned URL, valid for expiresIn, given checksum of the content and tenantId
+func Sign(unsigned url.URL, tenantId string, expiresIn time.Duration, checksum string, secret []byte) (*SignedUrl, error) {
+	if unsigned.Path == "" {
+		return nil, fmt.Errorf("cannot generate a signature for an empty path")
+	}
+	signer, err := blake2b.New256(secret)
+
+	// blake2b will error if len(byte) > 64 - keep this
+	if err != nil {
+		return nil, err
+	}
+
+	payload := newSignerPayload(unsigned, tenantId, expiresIn, checksum)
+	for _, part := range payload.GetPartsToSign() {
+		signer.Write(part)
+	}
+
+	return NewSignedFromSignature(unsigned, signer.Sum(nil))
+}
+
+func Verify(signed url.URL, secret []byte) error {
+	signer, err := blake2b.New256(secret)
+
+	if err != nil {
+		return fmt.Errorf("error when preparing for signature validation: %s", err)
+	}
+
+	providedSignature, err := base64.RawURLEncoding.DecodeString(signed.Query().Get(SignatureQueryParamName))
+	if err != nil {
+		return fmt.Errorf("could not decode signature '%s': %s", providedSignature, err)
+	}
+
+	payload, err := newSignerPayloadFromSigned(signed)
+
+	if err != nil {
+		return fmt.Errorf("error when preparing payload for signature validation: %s", err)
+	}
+
+	for _, part := range payload.GetPartsToSign() {
+		signer.Write(part)
+	}
+
+	computedSignature := signer.Sum(nil)
+
+	if subtle.ConstantTimeCompare(providedSignature, computedSignature) != 1 {
+		return fmt.Errorf("invalid signature: %s", providedSignature)
+	}
+
+	// check expiry if signature matches
+	if time.Now().UTC().After(time.Unix(payload.expiry, 0)) {
+		return fmt.Errorf("url is no longer valid")
+	}
+
+	return nil
+}

--- a/pkg/urlsign/signer_api.go
+++ b/pkg/urlsign/signer_api.go
@@ -12,7 +12,7 @@ import (
 
 // Sign uses a provided secret to generate a cryptographic signature for the provided unsigned URL, valid for expiresIn, given checksum of the content and tenantId
 func Sign(unsigned url.URL, tenantId string, expiresIn time.Duration, checksum string, secret []byte) (*SignedUrl, error) {
-	if unsigned.Path == "" {
+	if unsigned.Path == "" || unsigned.Path == "/" {
 		return nil, fmt.Errorf("cannot generate a signature for an empty path")
 	}
 	signer, err := blake2b.New256(secret)
@@ -27,7 +27,7 @@ func Sign(unsigned url.URL, tenantId string, expiresIn time.Duration, checksum s
 		signer.Write(part)
 	}
 
-	return NewSignedFromSignature(unsigned, signer.Sum(nil))
+	return NewSignedFromSignature(unsigned, payload, signer.Sum(nil))
 }
 
 func Verify(signed url.URL, secret []byte) error {

--- a/pkg/urlsign/signer_api.go
+++ b/pkg/urlsign/signer_api.go
@@ -38,6 +38,11 @@ func Verify(signed url.URL, secret []byte) error {
 	}
 
 	providedSignature, err := base64.RawURLEncoding.DecodeString(signed.Query().Get(SignatureQueryParamName))
+
+	if len(providedSignature) == 0 {
+		return fmt.Errorf("no signature found in the url")
+	}
+
 	if err != nil {
 		return fmt.Errorf("could not decode signature '%s': %s", providedSignature, err)
 	}
@@ -55,11 +60,11 @@ func Verify(signed url.URL, secret []byte) error {
 	computedSignature := signer.Sum(nil)
 
 	if subtle.ConstantTimeCompare(providedSignature, computedSignature) != 1 {
-		return fmt.Errorf("invalid signature: %s", providedSignature)
+		return fmt.Errorf("invalid signature: %s", signed.Query().Get(SignatureQueryParamName))
 	}
 
 	// check expiry if signature matches
-	if time.Now().UTC().After(time.Unix(payload.expiry, 0)) {
+	if time.Now().UTC().After(time.Unix(payload.validTo, 0)) {
 		return fmt.Errorf("url is no longer valid")
 	}
 

--- a/pkg/urlsign/signer_api_test.go
+++ b/pkg/urlsign/signer_api_test.go
@@ -1,0 +1,64 @@
+package urlsign
+
+import (
+	"fmt"
+	"math/rand"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func generateUrls(numUrls int) []string {
+	rnd := rand.New(rand.NewSource(1))
+
+	urls := make([]string, numUrls)
+	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
+	bucket := randomString(rnd, 8, charset)
+
+	for i := 0; i < numUrls; i++ {
+		prefix1 := randomString(rnd, 5, charset)
+
+		path := fmt.Sprintf("https://s3.svc.local", bucket, prefix1)
+		// add one more prefix randomly
+		if rnd.Intn(2) == 1 {
+			path += "/" + randomString(rnd, 5, charset)
+		}
+
+		// add query params
+		result, _ := url.Parse(path)
+		query := result.Query()
+
+		// 1 = one param, 2 = two params
+		numParams := rnd.Intn(2)
+		for paramIdx := 0; paramIdx < numParams; paramIdx++ {
+			paramKey := fmt.Sprintf("param%d", paramIdx)
+			paramValue := randomString(rnd, 5, charset)
+			query.Add(paramKey, paramValue)
+		}
+
+		result.RawQuery = query.Encode()
+		urls[i] = result.String()
+	}
+
+	return urls
+}
+
+func randomString(random *rand.Rand, desiredLength int, charset string) string {
+	result := make([]uint8, desiredLength)
+	for i := range result {
+		result[i] = charset[random.Intn(len(charset))]
+	}
+	return string(result)
+}
+
+func TestSignVerify(t *testing.T) {
+	secret := []byte("secret")
+	for _, unsigned := range generateUrls(5) {
+		parsed, err := url.Parse(unsigned)
+		if err != nil {
+			t.Fatalf("failed to parse url: %s", err)
+		}
+		signed, err := Sign(*parsed, "test", time.Hour, "test", secret)
+		Verify(*signed.Url, secret)
+	}
+}

--- a/pkg/urlsign/signer_api_test.go
+++ b/pkg/urlsign/signer_api_test.go
@@ -114,7 +114,7 @@ func TestVerifyEmptySignature(t *testing.T) {
 		t.Fatalf("successfully signed an invalid url")
 	}
 
-	if !strings.Contains(err.Error(), "invalid signature") {
+	if !strings.Contains(err.Error(), "no signature found in the url") {
 		t.Fatalf("incorrect error: %s", err)
 	}
 }

--- a/pkg/urlsign/signer_api_test.go
+++ b/pkg/urlsign/signer_api_test.go
@@ -123,11 +123,11 @@ func TestVerifyExpiry(t *testing.T) {
 	secret := []byte("secret")
 	parsed, _ := url.Parse("https://s3.svc.local/bucket/prefix1/prefix2/file.json")
 
-	signed, err := Sign(*parsed, "test", time.Second, "test", secret)
+	signed, _ := Sign(*parsed, "test", time.Second, "test", secret)
 
 	time.Sleep(time.Second * 2)
 
-	err = Verify(*signed.Url, secret)
+	err := Verify(*signed.Url, secret)
 
 	if err == nil {
 		t.Fatalf("successfully signed an expired signature")

--- a/pkg/urlsign/signer_api_test.go
+++ b/pkg/urlsign/signer_api_test.go
@@ -120,13 +120,14 @@ func TestVerifyEmptySignature(t *testing.T) {
 }
 
 func TestVerifyExpiry(t *testing.T) {
+	secret := []byte("secret")
 	parsed, _ := url.Parse("https://s3.svc.local/bucket/prefix1/prefix2/file.json")
 
-	signed, err := Sign(*parsed, "test", time.Second, "test", []byte("secret"))
+	signed, err := Sign(*parsed, "test", time.Second, "test", secret)
 
 	time.Sleep(time.Second * 2)
 
-	err = Verify(*signed.Url, []byte("test"))
+	err = Verify(*signed.Url, secret)
 
 	if err == nil {
 		t.Fatalf("successfully signed an expired signature")

--- a/pkg/urlsign/signer_api_test.go
+++ b/pkg/urlsign/signer_api_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 )
@@ -18,7 +19,7 @@ func generateUrls(numUrls int) []string {
 	for i := 0; i < numUrls; i++ {
 		prefix1 := randomString(rnd, 5, charset)
 
-		path := fmt.Sprintf("https://s3.svc.local", bucket, prefix1)
+		path := fmt.Sprintf("https://s3.svc.local/%s/%s", bucket, prefix1)
 		// add one more prefix randomly
 		if rnd.Intn(2) == 1 {
 			path += "/" + randomString(rnd, 5, charset)
@@ -59,6 +60,79 @@ func TestSignVerify(t *testing.T) {
 			t.Fatalf("failed to parse url: %s", err)
 		}
 		signed, err := Sign(*parsed, "test", time.Hour, "test", secret)
-		Verify(*signed.Url, secret)
+		if err != nil {
+			t.Fatalf("failed to sign: %s", err)
+		}
+
+		if signed == nil {
+			t.Fatalf("nil signature generated")
+		}
+
+		err = Verify(*signed.Url, secret)
+
+		if err != nil {
+			t.Fatalf("invalid signature: %s", err)
+		}
+	}
+}
+
+func TestSignVerifyInvalidIfNoPath(t *testing.T) {
+	parsed, _ := url.Parse("https://s3.svc.local/")
+
+	_, err := Sign(*parsed, "test", time.Hour, "test", []byte("secret"))
+
+	if err == nil {
+		t.Fatalf("successfully signed an invalid url")
+	}
+}
+
+func TestVerifyTampered(t *testing.T) {
+	secret := []byte("secret")
+	for _, unsigned := range generateUrls(5) {
+		parsed, _ := url.Parse(unsigned)
+		signed, _ := Sign(*parsed, "test", time.Hour, "test", secret)
+		sigQuery := signed.Url.Query()
+		sig := signed.Url.Query().Get("sig")
+		sigQuery.Set("sig", fmt.Sprintf("abc123%s", sig))
+
+		signed.Url.RawQuery = sigQuery.Encode()
+
+		err := Verify(*signed.Url, secret)
+
+		if err == nil {
+			t.Fatalf("a tampered signature verification should fail")
+		}
+	}
+}
+
+func TestVerifyEmptySignature(t *testing.T) {
+	parsed, _ := url.Parse("https://s3.svc.local/bucket/prefix?exp=1111&tid=123&chk=3123qdawqe")
+
+	err := Verify(*parsed, []byte("test"))
+
+	if err == nil {
+		t.Fatalf("successfully signed an invalid url")
+	}
+
+	if !strings.Contains(err.Error(), "invalid signature") {
+		t.Fatalf("incorrect error: %s", err)
+	}
+}
+
+func TestVerifyExpiry(t *testing.T) {
+	parsed, _ := url.Parse("https://s3.svc.local/bucket/prefix1/prefix2/file.json")
+
+	signed, err := Sign(*parsed, "test", time.Second, "test", []byte("secret"))
+
+	time.Sleep(time.Second * 2)
+
+	err = Verify(*signed.Url, []byte("test"))
+
+	if err == nil {
+		t.Fatalf("successfully signed an expired signature")
+	}
+
+	if !strings.Contains(err.Error(), "url is no longer valid") {
+		t.Fatalf("incorrect error: %s", err)
 	}
 }

--- a/pkg/urlsign/signer_payload.go
+++ b/pkg/urlsign/signer_payload.go
@@ -42,6 +42,10 @@ func newSignerPayloadFromSigned(signed url.URL) (*signerPayload, error) {
 
 	validTo, err := strconv.ParseInt(signed.Query().Get(ValidToQueryParamName), 10, 64)
 
+	if err != nil {
+		return nil, err
+	}
+
 	return &signerPayload{
 		validFrom: validFrom,
 		validTo:   validTo,

--- a/pkg/urlsign/signer_payload.go
+++ b/pkg/urlsign/signer_payload.go
@@ -1,0 +1,57 @@
+package urlsign
+
+import (
+	"encoding/binary"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+const (
+	ExpiryQueryParamName   = "exp"
+	TenantQueryParamName   = "tid"
+	ChecksumQueryParamName = "chk"
+)
+
+type signerPayload struct {
+	expiry   int64
+	path     string
+	tenantId string
+	checksum string
+}
+
+func newSignerPayload(unsigned url.URL, tenantId string, expiresIn time.Duration, checksum string) *signerPayload {
+	return &signerPayload{
+		expiry:   time.Now().Add(expiresIn).UTC().Unix(),
+		path:     unsigned.Path,
+		tenantId: tenantId,
+		checksum: checksum,
+	}
+}
+
+func newSignerPayloadFromSigned(signed url.URL) (*signerPayload, error) {
+	expiry, err := strconv.ParseInt(signed.Query().Get(ExpiryQueryParamName), 10, 64)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &signerPayload{
+		expiry:   expiry,
+		path:     signed.Path,
+		tenantId: signed.Query().Get(TenantQueryParamName),
+		checksum: signed.Query().Get(ChecksumQueryParamName),
+	}, nil
+}
+
+func (p *signerPayload) GetPartsToSign() [][]byte {
+	expiryBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(expiryBytes, uint64(p.expiry))
+
+	return [][]byte{
+		[]byte(p.path),
+		[]byte(p.tenantId),
+		[]byte(p.checksum),
+		expiryBytes,
+	}
+}

--- a/pkg/urlsign/signer_payload.go
+++ b/pkg/urlsign/signer_payload.go
@@ -8,50 +8,60 @@ import (
 )
 
 const (
-	ExpiryQueryParamName   = "exp"
-	TenantQueryParamName   = "tid"
-	ChecksumQueryParamName = "chk"
+	ValidFromQueryParamName = "from"
+	ValidToQueryParamName   = "to"
+	TenantQueryParamName    = "tid"
+	ChecksumQueryParamName  = "chk"
 )
 
 type signerPayload struct {
-	expiry   int64
-	path     string
-	tenantId string
-	checksum string
+	validFrom int64
+	validTo   int64
+	path      string
+	tenantId  string
+	checksum  string
 }
 
 func newSignerPayload(unsigned url.URL, tenantId string, expiresIn time.Duration, checksum string) *signerPayload {
+	startTime := time.Now()
 	return &signerPayload{
-		expiry:   time.Now().Add(expiresIn).UTC().Unix(),
-		path:     unsigned.Path,
-		tenantId: tenantId,
-		checksum: checksum,
+		validFrom: startTime.UTC().Unix(),
+		validTo:   startTime.Add(expiresIn).UTC().Unix(),
+		path:      unsigned.Path,
+		tenantId:  tenantId,
+		checksum:  checksum,
 	}
 }
 
 func newSignerPayloadFromSigned(signed url.URL) (*signerPayload, error) {
-	expiry, err := strconv.ParseInt(signed.Query().Get(ExpiryQueryParamName), 10, 64)
+	validFrom, err := strconv.ParseInt(signed.Query().Get(ValidFromQueryParamName), 10, 64)
 
 	if err != nil {
 		return nil, err
 	}
 
+	validTo, err := strconv.ParseInt(signed.Query().Get(ValidToQueryParamName), 10, 64)
+
 	return &signerPayload{
-		expiry:   expiry,
-		path:     signed.Path,
-		tenantId: signed.Query().Get(TenantQueryParamName),
-		checksum: signed.Query().Get(ChecksumQueryParamName),
+		validFrom: validFrom,
+		validTo:   validTo,
+		path:      signed.Path,
+		tenantId:  signed.Query().Get(TenantQueryParamName),
+		checksum:  signed.Query().Get(ChecksumQueryParamName),
 	}, nil
 }
 
 func (p *signerPayload) GetPartsToSign() [][]byte {
-	expiryBytes := make([]byte, 8)
-	binary.LittleEndian.PutUint64(expiryBytes, uint64(p.expiry))
+	fromBytes := make([]byte, 8)
+	toBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(fromBytes, uint64(p.validFrom))
+	binary.LittleEndian.PutUint64(toBytes, uint64(p.validTo))
 
 	return [][]byte{
 		[]byte(p.path),
 		[]byte(p.tenantId),
 		[]byte(p.checksum),
-		expiryBytes,
+		fromBytes,
+		toBytes,
 	}
 }


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/nexus-core/issues/68

Added a new package, `urlsign`, which provides functionality for generating and verifying signed URLs. The main features include cryptographic signing of URLs with expiry, tenant, and checksum metadata + verification.

**New signed URL functionality:**

* Added `Sign` and `Verify` functions in `pkg/urlsign/signer_api.go` to generate and validate cryptographically signed URLs using the Blake2b algorithm.

**AI summary - edited**